### PR TITLE
CI: Use correct name for github-token when creating release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create Release Notes
         uses: actions/github-script@v4.0.2
         with:
-          github-token: ${{secrets.GH_TOKEN}}
+          github-token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
               tag_name: "${{ github.ref }}",


### PR DESCRIPTION
GH releases aren't working because it references a nonexistent secret. This PR fixes that.