### PR TITLE
Build: Support for building nested plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@grafana/eslint-config": "^2.5.0",
     "@swc/jest": "^0.2.20",
+    "@types/glob": "^7.0.0",
     "@types/jest": "^27.4.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/templates/common/.config/README.md
+++ b/templates/common/.config/README.md
@@ -90,7 +90,7 @@ import grafanaConfig from './.config/webpack/webpack.config';
 const config = async (env) => {
   const baseConfig = await grafanaConfig(env);
 
-  merge(baseConfig, {
+  return merge(baseConfig, {
     // Add custom config here...
     output: {
       asyncChunks: true,
@@ -99,6 +99,7 @@ const config = async (env) => {
 };
 
 export default config;
+
 ```
 
 #### 3. Update the `package.json` to use the new Webpack config

--- a/templates/common/.config/README.md
+++ b/templates/common/.config/README.md
@@ -87,13 +87,16 @@ We are going to use [`webpack-merge`](https://github.com/survivejs/webpack-merge
 import { merge } from 'webpack-merge';
 import grafanaConfig from './.config/webpack/webpack.config';
 
-const config = (env) =>
-    merge(grafanaConfig(env), {
-        // Add custom config here...
-        output: {
-            asyncChunks: true,
-        },
-    });
+const config = async (env) => {
+  const baseConfig = await grafanaConfig(env);
+
+  merge(baseConfig, {
+    // Add custom config here...
+    output: {
+      asyncChunks: true,
+    },
+  });
+};
 
 export default config;
 ```

--- a/templates/common/.config/README.md
+++ b/templates/common/.config/README.md
@@ -84,10 +84,11 @@ We are going to use [`webpack-merge`](https://github.com/survivejs/webpack-merge
 
 ```typescript
 // webpack.config.ts
+import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 import grafanaConfig from './.config/webpack/webpack.config';
 
-const config = async (env) => {
+const config = async (env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   return merge(baseConfig, {

--- a/templates/common/.config/webpack/constants.ts
+++ b/templates/common/.config/webpack/constants.ts
@@ -1,3 +1,2 @@
 export const SOURCE_DIR = 'src';
 export const DIST_DIR = 'dist';
-export const ENTRY_FILE = `${SOURCE_DIR}/module.ts`;

--- a/templates/common/.config/webpack/utils.ts
+++ b/templates/common/.config/webpack/utils.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
+import util from 'util';
+import glob from 'glob';
 import { SOURCE_DIR } from './constants';
+
+const globAsync = util.promisify(glob);
 
 export function getPackageJson() {
   return require(path.resolve(process.cwd(), 'package.json'));
@@ -14,4 +18,24 @@ export function getPluginId() {
 
 export function hasReadme() {
   return fs.existsSync(path.resolve(process.cwd(), SOURCE_DIR, 'README.md'));
+}
+
+export async function getEntries(): Promise<Record<string, string>> {
+  const parent = `..${path.sep}`;
+  const pluginsJson = await globAsync('**/src/**/plugin.json');
+  
+  const plugins = await Promise.all(pluginsJson.map(pluginJson => {
+    const folder = path.dirname(pluginJson);
+    return globAsync(`${folder}/module.{ts,tsx,js}`);
+  }));
+
+  return plugins.reduce((result, modules) => {
+    return modules.reduce((result, module) => {
+      const pluginPath = path.resolve(path.dirname(module), parent);
+      const pluginName = path.basename(pluginPath);
+  
+      result[`${pluginName}/module`] = path.join(parent, module);
+      return result;
+    }, result);
+  }, {});
 }

--- a/templates/common/.config/webpack/utils.ts
+++ b/templates/common/.config/webpack/utils.ts
@@ -21,7 +21,7 @@ export function hasReadme() {
 }
 
 export async function getEntries(): Promise<Record<string, string>> {
-  const parent = `..${path.sep}`;
+  const parent = '..';
   const pluginsJson = await globAsync('**/src/**/plugin.json');
   
   const plugins = await Promise.all(pluginsJson.map(pluginJson => {

--- a/templates/common/.config/webpack/webpack.config.ts
+++ b/templates/common/.config/webpack/webpack.config.ts
@@ -12,10 +12,10 @@ import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import { Configuration } from 'webpack';
 
-import { getPackageJson, getPluginId, hasReadme } from './utils';
-import { SOURCE_DIR, DIST_DIR, ENTRY_FILE } from './constants';
+import { getPackageJson, getPluginId, hasReadme, getEntries } from './utils';
+import { SOURCE_DIR, DIST_DIR } from './constants';
 
-const config = (env): Configuration => ({
+const config = async (env): Promise<Configuration> => ({
   cache: {
     type: 'filesystem',
     buildDependencies: {
@@ -27,9 +27,7 @@ const config = (env): Configuration => ({
 
   devtool: env.production ? 'source-map' : 'eval-source-map',
 
-  entry: {
-    module: path.resolve(process.cwd(), ENTRY_FILE),
-  },
+  entry: await getEntries(),
 
   externals: [
     'lodash',

--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -30,6 +30,7 @@
     "@types/jest": "^27.4.1",{{#if_eq pluginType "app"}}
     "@types/react-router-dom": "^5.3.3",{{/if_eq}}
     "@types/node": "^17.0.19",
+    "@types/glob": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "copy-webpack-plugin": "^10.0.0",
@@ -50,7 +51,8 @@
     "typescript": "^4.4.0",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
-    "webpack-livereload-plugin": "^3.0.2"
+    "webpack-livereload-plugin": "^3.0.2",
+    "glob": "^8.0.3"
   },
   "engines": {
     "node": ">=14"

--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -27,10 +27,10 @@
     "@swc/jest": "^0.2.20",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
+    "@types/glob": "^8.0.0",
     "@types/jest": "^27.4.1",{{#if_eq pluginType "app"}}
     "@types/react-router-dom": "^5.3.3",{{/if_eq}}
     "@types/node": "^17.0.19",
-    "@types/glob": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "copy-webpack-plugin": "^10.0.0",
@@ -41,6 +41,7 @@
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-webpack-plugin": "^3.1.1",
+    "glob": "^8.0.3",
     "jest": "27.5.0",
     "fork-ts-checker-webpack-plugin": "^7.2.0",
     "prettier": "^2.5.0",
@@ -51,8 +52,7 @@
     "typescript": "^4.4.0",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2",
-    "webpack-livereload-plugin": "^3.0.2",
-    "glob": "^8.0.3"
+    "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
     "node": ">=14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,7 +767,7 @@
   resolved "https://registry.yarnpkg.com/@types/fined/-/fined-1.1.3.tgz#83f03e8f0a8d3673dfcafb18fce3571f6250e1bc"
   integrity sha512-CWYnSRnun3CGbt6taXeVo2lCbuaj4mchVJ4UF/BdU5TSuIn3AmS13pGMwCsBUoehGbhZrBrpNJZSZI5EVilXww==
 
-"@types/glob@^7.1.1":
+"@types/glob@^7.0.0", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
   integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==


### PR DESCRIPTION
This PR will add support for building nested plugins to the generated webpack configuration.

I have changed the exported webpack config to return a `Promise<Configuration>` instead of a `Configuration`. Will this cause any issues for plugins overriding the configuration?

Fixes #33