### PR TITLE
Bugfix: building a single plugin as module directly in the dist folder

### DIFF
--- a/templates/common/.config/webpack/utils.ts
+++ b/templates/common/.config/webpack/utils.ts
@@ -33,8 +33,9 @@ export async function getEntries(): Promise<Record<string, string>> {
     return modules.reduce((result, module) => {
       const pluginPath = path.resolve(path.dirname(module), parent);
       const pluginName = path.basename(pluginPath);
+      const entryName = plugins.length > 1 ? `${pluginName}/module` : 'module';
   
-      result[`${pluginName}/module`] = path.join(parent, module);
+      result[entryName] = path.join(parent, module);
       return result;
     }, result);
   }, {});


### PR DESCRIPTION
When I introduced #50 I broke the support for single plugin repositories by always put the plugin `dist/${pluginName}/module.js`. This PR will fix that issue by always putting a single plugin repo directly below `dist/module.js`.

We should probably add tests for the most simple scenarios. Will open another PR about that.