### PR TITLE
Updates README about creating a new plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you have questions or need help, please ask in [GitHub Discussions](https://g
 
 * `mkdir -p $HOME/grafana-plugins && cd $HOME/grafana-plugins`
 * Run `yarn create @grafana/plugin` and follow the questions
-* Cd to the plugin directory. e.g.: `cd my-org-my-plugin-name`
+* Cd to your new plugin directory. e.g.: `cd my-org-my-plugin-name`
 * Install the dependencies: `yarn install`
 * Start developing: `yarn dev` (will watch changes in your plugin code and rebuild)
 
@@ -42,6 +42,7 @@ If you have questions or need help, please ask in [GitHub Discussions](https://g
 * Open http://localhost:3000
 * Auth with username admin and password admin. Change the password.
 * Visit `Configuration -> Plugins` and see if your new plugin is listed there as installed.
+* Perform changes to your plugin and refresh grafana to see them. (remember to keep `yarn dev` running in your plugin)
 
 You can see more information on building grafana plugins [here](https://grafana.com/tutorials/build-a-panel-plugin/). NOTE: This guide might still contain references to toolkit. Skip to the "Anatomy of a plugin" section.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Grafana / Create Plugin
 
 Create Grafana plugins with ease.
@@ -7,7 +8,6 @@ Create Grafana plugins with ease.
 - [Create a new plugin](#create-a-new-plugin)
 - [Migrate your existing plugin](#migrate-your-existing-plugin)
 - [Update your plugin build config](#update-your-plugin-build-config)
-- [Start developing your plugin](#start-developing-your-plugin)
 - [Contributing](#contributing)
 
 **Links**
@@ -16,49 +16,16 @@ Create Grafana plugins with ease.
 - [Plugin migration guide](https://grafana.com/docs/grafana/latest/developers/plugins/migration-guide/)
 
 **`@grafana/create-plugin`** works on macOS, Windows and Linux.<br />
-If something doesn’t work, please [file an issue](https://github.com/grafana/create-plugin/issues/new).<br />
+If something doesn't work, please [file an issue](https://github.com/grafana/create-plugin/issues/new).<br />
 If you have questions or need help, please ask in [GitHub Discussions](https://github.com/grafana/create-plugin/discussions).
 
-## Create a new grafana plugin
+## Create a new plugin
 
-### Scaffolding
+### Quick overview
 
-* `mkdir -p $HOME/grafana-plugins && cd $HOME/grafana-plugins`
-* Run `yarn create @grafana/plugin` and follow the questions
-* Cd to your new plugin directory. e.g.: `cd my-org-my-plugin-name`
-* Install the dependencies: `yarn install`
-* Start developing: `yarn dev` (will watch changes in your plugin code and rebuild)
+Run the command in the folder where you want to store your plugins. The new plugin will be scaffolded in a sub-director of the folder where you run the command.
 
-### Run your plugin inside grafana (docker example)
-
-* Run grafana inside docker:
-
-  ```bash
-  docker run -p 3000:3000 -v "$HOME"/grafana-plugins:/var/lib/grafana/plugins --name=grafana grafana/grafana:9.1.2
-  ```
-
-  NOTE: If you add or remove a plugin inside `$HOME/grafana-plugins` you need to restart grafana.
-
-* Open http://localhost:3000
-* Auth with username admin and password admin. Change the password.
-* Visit `Configuration -> Plugins` and see if your new plugin is listed there as installed.
-* Perform changes to your plugin and refresh grafana to see them. (remember to keep `yarn dev` running in your plugin)
-
-You can see more information on building grafana plugins [here](https://grafana.com/tutorials/build-a-panel-plugin/). NOTE: This guide might still contain references to toolkit. Skip to the "Anatomy of a plugin" section.
-
-## Alternatives syntaxes to run create-plugin
-
-#### [`npx`](https://github.com/npm/npx)
-
-```bash
-npx @grafana/create-plugin
-```
-
-#### [`npm`](https://docs.npmjs.com/cli/v7/commands/npm-init)
-
-```bash
-npm init @grafana/plugin
-```
+You can run the command with the package manager of your choice:
 
 #### [`yarn`](https://classic.yarnpkg.com/blog/2017/05/12/introducing-yarn/) (1.x)
 
@@ -70,6 +37,18 @@ yarn create @grafana/plugin
 
 ```bash
 yarn dlx @grafana/create-plugin
+```
+
+#### [`npx`](https://github.com/npm/npx)
+
+```bash
+npx @grafana/create-plugin
+```
+
+#### [`npm`](https://docs.npmjs.com/cli/v7/commands/npm-init)
+
+```bash
+npm init @grafana/plugin
 ```
 
 ---
@@ -111,43 +90,6 @@ npx @grafana/create-plugin update
 
 ---
 
-## Start developing your plugin
-
-We have put together the following dev scripts for you, so you can start coding right away:
-
-#### `yarn dev`
-
-Starts the build in watch mode.
-The build output (plugin bundle) is going to be exported to `./dist`.
-
-#### `yarn build`
-
-Creates a production build for your plugin.
-The build output is going to be exported to `./dist`.
-
-#### `yarn test`
-
-Runs the tests under `./src` directory in watch mode.
-Give your test files a `.test.tsx` or `.test.ts` extension.
-
-#### `yarn test:ci`
-
-Runs the tests and returns with either a zero or a non-zero exit status.
-
-#### `yarn typecheck`
-
-Runs the Typescript compiler against the codebase in a dry-run mode to highlight any type errors or warnings.
-
-#### `yarn lint`
-
-Runs ESLint against the codebase.
-
-#### `yarn lint:fix`
-
-Runs ESLint against the codebase and attempts to fix the simpler errors.
-
----
-
 ## Customizing or extending the basic configs
 
 You can read more about customizing or extending the basic configuration [here](templates/common/.config/README.md)
@@ -155,3 +97,4 @@ You can read more about customizing or extending the basic configuration [here](
 ## Contributing
 
 We are always grateful for contribution! See the [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
+

--- a/README.md
+++ b/README.md
@@ -19,20 +19,33 @@ Create Grafana plugins with ease.
 If something doesn’t work, please [file an issue](https://github.com/grafana/create-plugin/issues/new).<br />
 If you have questions or need help, please ask in [GitHub Discussions](https://github.com/grafana/create-plugin/discussions).
 
-## Create a new plugin
+## Create a new grafana plugin
 
-### Quick overview
+### Scaffolding
 
-The following commands scaffold a Grafana plugin inside the `./my-plugin` folder:
+* `mkdir -p $HOME/grafana-plugins && cd $HOME/grafana-plugins`
+* Run `yarn create @grafana/plugin` and follow the questions
+* Cd to the plugin directory. e.g.: `cd my-org-my-plugin-name`
+* Install the dependencies: `yarn install`
+* Start developing: `yarn dev` (will watch changes in your plugin code and rebuild)
 
-```bash
-mkdir my-plugin && cd my-plugin
-yarn create @grafana/plugin
-yarn install
-yarn dev
-```
+### Run your plugin inside grafana (docker example)
 
-Alterntives:
+* Run grafana inside docker:
+
+  ```bash
+  docker run -p 3000:3000 -v "$HOME"/grafana-plugins:/var/lib/grafana/plugins --name=grafana grafana/grafana:9.1.2
+  ```
+
+  NOTE: If you add or remove a plugin inside `$HOME/grafana-plugins` you need to restart grafana.
+
+* Open http://localhost:3000
+* Auth with username admin and password admin. Change the password.
+* Visit `Configuration -> Plugins` and see if your new plugin is listed there as installed.
+
+You can see more information on building grafana plugins [here](https://grafana.com/tutorials/build-a-panel-plugin/). NOTE: This guide might still contain references to toolkit. Skip to the "Anatomy of a plugin" section.
+
+## Alternatives syntaxes to run create-plugin
 
 #### [`npx`](https://github.com/npm/npx)
 


### PR DESCRIPTION
Closes https://github.com/grafana/create-plugin/issues/53

Removes extended description on how to create and run a plugin. This content should be later part of the main documentation.