### PR TITLE
Templates: Set timezone to UTC for jest

### DIFF
--- a/templates/common/jest.config.js
+++ b/templates/common/jest.config.js
@@ -1,3 +1,7 @@
+// force timezone to UTC to allow tests to work regardless of local timezone
+// generally used by snapshots, but can affect specific tests
+process.env.TZ = 'UTC';
+
 module.exports = {
   // Jest configuration provided by Grafana scaffolding
   ...require('./.config/jest.config'),


### PR DESCRIPTION
Snapshots and tests that use Date() will fail when generated locally in different timezones.  This forces jest to use UTC so the results will be reliable.

fixes #60