### PR TITLE
Templates: Use plugincheck2 in release workflow

### DIFF
--- a/templates/github/ci/.github/workflows/release.yml
+++ b/templates/github/ci/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Lint plugin
         run: |
           git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/cmd/plugincheck
+          pushd ./plugin-validator/cmd/plugincheck2
           go install
           popd
           plugincheck2 -config ./plugin-validator/config/publishing.yaml $\{{ steps.metadata.outputs.archive }}

--- a/templates/github/ci/.github/workflows/release.yml
+++ b/templates/github/ci/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Lint plugin
         run: |
           git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/cmd/plugincheck2
+          pushd ./plugin-validator/pkg/cmd/plugincheck2
           go install
           popd
           plugincheck2 -config ./plugin-validator/config/publishing.yaml $\{{ steps.metadata.outputs.archive }}

--- a/templates/github/ci/.github/workflows/release.yml
+++ b/templates/github/ci/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           pushd ./plugin-validator/cmd/plugincheck
           go install
           popd
-          plugincheck $\{{ steps.metadata.outputs.archive }}
+          plugincheck2 -config ./plugin-validator/config/publishing.yaml $\{{ steps.metadata.outputs.archive }}
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
Moving the release workflow to use plugincheck2 and the publishing config.

Fixes: #43 