### PR TITLE
Migrate: Sort package.json fields

### DIFF
--- a/src/commands/migrate.command.ts
+++ b/src/commands/migrate.command.ts
@@ -9,6 +9,7 @@ import {
   getRemovableNpmDependencies,
   removeNpmDependencies,
   updateNpmScripts,
+  cleanUpPackageJson,
 } from '../utils/utils.npm';
 
 export const migrate = async () => {
@@ -90,7 +91,11 @@ export const migrate = async () => {
       printMessage(TEXT.updateNpmScriptsAborted);
     }
 
-    // 4. Summary
+    // Tidy package.json file so any changed fields are sorted as a
+    // package manager would expect.
+    cleanUpPackageJson();
+
+    // 7. Summary
     // -------------
     printSuccessMessage(TEXT.migrationCommandSuccess);
   } catch (error) {

--- a/src/utils/utils.npm.ts
+++ b/src/utils/utils.npm.ts
@@ -187,3 +187,20 @@ export function updateNpmScripts() {
 
   writePackageJson(packageJson);
 }
+
+export function cleanUpPackageJson() {
+  const packageJson = getPackageJson();
+  packageJson.scripts = sortKeysAlphabetically(packageJson.scripts);
+  packageJson.dependencies = sortKeysAlphabetically(packageJson.dependencies);
+  packageJson.devDependencies = sortKeysAlphabetically(packageJson.devDependencies);
+  writePackageJson(packageJson);
+}
+
+function sortKeysAlphabetically(obj: Record<string, string>) {
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, string>>((acc, key) => {
+      acc[key] = obj[key];
+      return acc;
+    }, {});
+}


### PR DESCRIPTION
This PR adds a clean up function to make sure the package.json is in a state that package managers would expect (alphabetised dependencies and devDependencies) and scripts are sorted to make it easier for a developer to scan.

| Before | After |
| --- | --- |
| <img width="978" alt="Screenshot 2022-10-06 at 12 11 08" src="https://user-images.githubusercontent.com/73201/194287510-ea573ebb-4aa5-4a38-b416-7d662b303ec5.png"> | <img width="979" alt="Screenshot 2022-10-06 at 12 09 49" src="https://user-images.githubusercontent.com/73201/194287521-4d2ac23e-4429-460a-88ac-8fee06208cae.png"> |
 

Fixes: #48