### PR TITLE
Templates: move @types/lodash and add react and react-dom to dependencies

### DIFF
--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -28,7 +28,8 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@types/glob": "^8.0.0",
-    "@types/jest": "^27.4.1",{{#if_eq pluginType "app"}}
+    "@types/jest": "^27.4.1",
+    "@types/lodash": "latest",{{#if_eq pluginType "app"}}
     "@types/react-router-dom": "^5.3.3",{{/if_eq}}
     "@types/node": "^17.0.19",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -62,8 +63,8 @@
     "@grafana/data": "{{ grafanaVersion }}",
     "@grafana/runtime": "{{ grafanaVersion }}",
     "@grafana/ui": "{{ grafanaVersion }}",
-    "@types/lodash": "latest"{{#if_eq pluginType "app"}},
-    "react-router-dom": "^5.2.0"
-    {{/if_eq}}
+    "react": "17.0.2",
+    "react-dom": "17.0.2"{{#if_eq pluginType "app"}},
+    "react-router-dom": "^5.2.0"{{/if_eq}}
   }
 }


### PR DESCRIPTION
This PR moves `@types/lodash` to devDependencies and adds `react` and `react-dom` to dependencies to remove unmet peer dependency warnings.

Fixes: #63 