### PR TITLE
Templates: Externalise react-router to prevent bundling with plugins

### DIFF
--- a/templates/common/.config/webpack/webpack.config.ts
+++ b/templates/common/.config/webpack/webpack.config.ts
@@ -45,6 +45,7 @@ const config = async (env): Promise<Configuration> => ({
     'react-redux',
     'redux',
     'rxjs',
+    'react-router',
     'react-router-dom',
     'd3',
     'angular',


### PR DESCRIPTION
Adding this fix for app plugins that bundling as per this recent [toolkit change](https://github.com/grafana/grafana/pull/54519/files#diff-ab8cd65444c9468f00e7a77245af7724728e3f24105761c449531f9eee1a6090)